### PR TITLE
Creating and saving CashBookEntries breaks

### DIFF
--- a/lib/economic/cash_book_entry.rb
+++ b/lib/economic/cash_book_entry.rb
@@ -91,7 +91,7 @@ module Economic
       data['AmountDefaultCurrency'] = amount_default_currency
       data['CurrencyHandle'] = { 'Code' => currency_handle[:code] } unless currency_handle.blank?
       data['Amount'] = amount
-      data['VatAccountHandle'] = { 'Number' => vat_account_handle[:number] } unless vat_account_handle.blank?
+      data['VatAccountHandle'] = { 'VatCode' => vat_account_handle[:vat_code] } unless vat_account_handle.blank?
       data['ContraVatAccountHandle'] = { 'Number' => contra_vat_account_handle[:number] } unless contra_vat_account_handle.blank?
       data['DebtorInvoiceNumber'] = debtor_invoice_number unless debtor_invoice_number.blank?
       data['CreditorInvoiceNumber'] = creditor_invoice_number unless creditor_invoice_number.blank?


### PR DESCRIPTION
Had problems with the soap-request blowing up in a book keeping-script I wrote. I'm not using the script right now, but I thought you would like to have this in case you're able to reproduce the issue. This was a change I did on the 0.4 version of the gem.
