### PR TITLE
Added possibility to add text lines to the current invoice

### DIFF
--- a/lib/economic/current_invoice.rb
+++ b/lib/economic/current_invoice.rb
@@ -48,7 +48,9 @@ module Economic
       :gross_amount,
       :margin,
       :margin_as_percent,
-      :heading
+      :heading,
+      :text_line1,
+      :text_line2
 
     defaults(
       :id => 0,
@@ -173,6 +175,8 @@ module Economic
         ["LayoutHandle", :layout_handle, to_hash],
         ["DeliveryDate", :delivery_date, date_formatter, :required],
         ["Heading", :heading],
+        ['TextLine1', :text_line1],
+        ['TextLine2', :text_line2],
         ["NetAmount", :net_amount, nil, :required],
         ["VatAmount", :vat_amount, nil, :required],
         ["GrossAmount", :gross_amount, nil, :required],


### PR DESCRIPTION
This adds the possibility to add text line 1 and text line 2. These values are set by the attribute `text_line1` and `text_line2` of the current invoice.
