### PR TITLE
Add ability to create CreditorInvoice entries using CreditorHandle

### DIFF
--- a/lib/economic/cash_book_entry.rb
+++ b/lib/economic/cash_book_entry.rb
@@ -82,6 +82,7 @@ module Economic
         ["Type", :type],
         ["CashBookHandle", :cash_book_handle, to_hash],
         ["DebtorHandle", :debtor_handle, to_hash],
+        ["CreditorHandle", :creditor_handle, to_hash],
         ["AccountHandle", :account_handle, to_hash],
         ["ContraAccountHandle", :contra_account_handle, to_hash],
         ["Date", :date, nil, :required],

--- a/spec/economic/cash_book_entry_spec.rb
+++ b/spec/economic/cash_book_entry_spec.rb
@@ -46,5 +46,28 @@ describe Economic::CashBookEntry do
       )
       subject.save
     end
+
+    it "can build a CashBookEntry with a CreditorHandle" do
+      time = Time.now
+      subject.date = subject.start_date = time
+      subject.creditor_handle = Economic::Entity::Handle.new(:number => 12)
+      mock_request(
+        :cash_book_entry_create_from_data, {
+          "data" => {
+            "CreditorHandle" => {"Number" => 12},
+            "Date" => time,
+            "VoucherNumber" => 0,
+            "Text" => "",
+            "AmountDefaultCurrency" => 0,
+            "Amount" => 0,
+            "DueDate" => nil,
+            "StartDate" => time,
+            "EndDate" => nil
+          }
+        },
+        :success
+      )
+      subject.save
+    end
   end
 end


### PR DESCRIPTION
Without this the API would not allow the creation of CashBookEntries of
type CreditorInvoice directly on the creditor.
