### PR TITLE
codeclimate now uses the `simplecov` gem for reporting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gemspec
 group :test do
   gem "codeclimate-test-reporter", :require => false
   gem "rake"
+  gem "simplecov", :require => false
 end
 
 # Not required to develop rconomic, but useful. See file

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
-require "codeclimate-test-reporter"
-CodeClimate::TestReporter.start
+require "simplecov"
+SimpleCov.start
 
 require "savon"
 require "savon/mock/spec_helper"


### PR DESCRIPTION
It simply did not run any tests on my system with the previous
`CodeClimate::TestReporter.start`

more info:
https://docs.codeclimate.com/docs/ruby