### PR TITLE
nokogiri 1.7.0.1 is incompatible with ruby 2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 # Specify which ruby versions you wish to run your tests on, each version will be used
 rvm:
-  - 2.0.0
   - 2.1.8
   - 2.2.4
   - 2.3.0


### PR DESCRIPTION
works from 2.1.0 and up, though, so I have dropped testing with ruby 2.0.0
Alternatively, we could use an older version of `nokogiri`