### PR TITLE
Make Ruby 2.0 builds pass on Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ spec/*.log
 .rvmrc
 Gemfile.lock
 /coverage/
+/gemfiles/*.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 # Specify which ruby versions you wish to run your tests on, each version will be used
 rvm:
-  - 2.0.0
   - 2.1.8
   - 2.2.4
   - 2.3.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,8 @@ notifications:
 addons:
   code_climate:
     repo_token: 6746eb72f5d9759f7d83ea90e8f49e3f01480d3b8f6334eea9e7cd9991c41ea4
+
+matrix:
+  include:
+    - rvm: 2.0.0
+      gemfile: gemfiles/Gemfile.ruby-2.0

--- a/gemfiles/Gemfile.ruby-2.0
+++ b/gemfiles/Gemfile.ruby-2.0
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "nokogiri", "< 1.7"
+gem "rack", "< 2.0"
 
 gemspec :path => "../"
 

--- a/gemfiles/Gemfile.ruby-2.0
+++ b/gemfiles/Gemfile.ruby-2.0
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "nokogiri", "< 1.7"
+
+gemspec :path => "../"
+
+group :test do
+  gem "codeclimate-test-reporter", :require => false
+  gem "rake"
+  gem "simplecov", :require => false
+end


### PR DESCRIPTION
Instead of dropping support for Ruby 2.0 (#48) we can tell Travis to use compatible gem versions.