### PR TITLE
Fix authentication when using legacy Connect

### DIFF
--- a/lib/economic/session.rb
+++ b/lib/economic/session.rb
@@ -9,7 +9,7 @@ module Economic
     def_delegators :endpoint, :logger=, :log_level=, :log=
 
     attr_accessor :agreement_number, :user_name, :password, :app_identifier
-    attr_reader :authentication_token
+    attr_reader :authentication_cookies
 
     def initialize(agreement_number = nil, user_name = nil, password = nil, app_identifier = nil)
       self.agreement_number = agreement_number
@@ -34,7 +34,7 @@ module Economic
         :token => access_id,
         :appToken => private_app_id
       ) do |response|
-        store_authentication_token(response)
+        store_authentication_cookies(response)
       end
     end
 
@@ -56,7 +56,7 @@ module Economic
         :userName => user_name,
         :password => password
       ) do |response|
-        store_authentication_token(response)
+        store_authentication_cookies(response)
       end
     end
 
@@ -132,7 +132,7 @@ module Economic
 
     # Requests an action from the API endpoint
     def request(soap_action, data = nil)
-      endpoint.call(soap_action, data, authentication_token)
+      endpoint.call(soap_action, data, authentication_cookies)
     end
 
     # Returns self - used by proxies to access the session of their owner
@@ -147,8 +147,9 @@ module Economic
 
     private
 
-    def store_authentication_token(response)
-      @authentication_token = response.http.cookies
+    def store_authentication_cookies(response)
+      cookies = response.http.cookies
+      @authentication_cookies = cookies
     end
   end
 end

--- a/lib/rconomic.rb
+++ b/lib/rconomic.rb
@@ -1,6 +1,7 @@
 # Dependencies
 require "time"
 require "savon"
+require "savon_ext/request"
 
 require "economic/support/string"
 require "economic/session"

--- a/lib/savon_ext/request.rb
+++ b/lib/savon_ext/request.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Savon
+  class SOAPRequest < HTTPRequest
+    def build(options = {})
+      configure_proxy
+      configure_timeouts
+      configure_headers options[:soap_action]
+      configure_cookies options[:cookies]
+      configure_ssl
+      configure_auth
+      configure_redirect_handling
+
+      @http_request
+    end
+  end
+end

--- a/spec/economic/session_spec.rb
+++ b/spec/economic/session_spec.rb
@@ -59,7 +59,7 @@ describe Economic::Session do
 
       subject.connect_with_credentials(*credentials)
 
-      expect(subject.authentication_token.collect { |cookie|
+      expect(subject.authentication_cookies.collect { |cookie|
         cookie.name_and_value.split("=").last
       }).to eq(["cookie value from e-conomic"])
     end
@@ -80,10 +80,10 @@ describe Economic::Session do
       other_session = Economic::Session.new
       other_session.connect_with_credentials(123_456, "api", "passw0rd")
 
-      expect(subject.authentication_token.collect { |cookie|
+      expect(subject.authentication_cookies.collect { |cookie|
         cookie.name_and_value.split("=").last
       }).to eq(["authentication token"])
-      expect(other_session.authentication_token.collect { |cookie|
+      expect(other_session.authentication_cookies.collect { |cookie|
         cookie.name_and_value.split("=").last
       }).to eq(["another token"])
     end
@@ -119,7 +119,7 @@ describe Economic::Session do
 
       subject.connect_with_token private_app_id, access_id
 
-      expect(subject.authentication_token.collect { |cookie|
+      expect(subject.authentication_cookies.collect { |cookie|
         cookie.name_and_value.split("=").last
       }).to eq(["cookie value from e-conomic"])
     end
@@ -140,10 +140,10 @@ describe Economic::Session do
       other_session = Economic::Session.new
       other_session.connect_with_credentials(123_456, "api", "passw0rd")
 
-      expect(subject.authentication_token.collect { |cookie|
+      expect(subject.authentication_cookies.collect { |cookie|
         cookie.name_and_value.split("=").last
       }).to eq(["authentication token"])
-      expect(other_session.authentication_token.collect { |cookie|
+      expect(other_session.authentication_cookies.collect { |cookie|
         cookie.name_and_value.split("=").last
       }).to eq(["another token"])
     end


### PR DESCRIPTION
So it seems there's a bug in Savon 2.11.1 where the `Cookie` header is not used in requests if you also specify a `globals[:headers]`. Since we need to push the `X-EconomicAppIdentifier` in headers AND also need cookies to ensure we stay logged in, we're stuffed.

This surfaces as a

    `raise_soap_and_http_errors!': (soap:Client)
    Economic.Api.Exceptions.AuthenticationException(E02250): Not logged in -
    could not resolve authenticationContext. This may be caused by invalid
    session cookie header. Read more at: https://www.e-conomic.com/developer
    /about-the-soap-api. (id=74eeddad-ad51-40fb-8f9b-bbb6be81f029)
    (Savon::SOAPFault)

when using `connect_with_credentials`. As far as I can tell, `connect_with_token` is not affected.

The bug in Savon has been fixed upstream, but there has been no release of Savon for ages that we can actually rely on. So, we're even more stuffed.

Monkeypatching Savon with a working instance of `Savon::SOAPRequest#build` that doesn't clobber the `Cookie` header seems like the lesser evil here.

The alternative, I guess, would be to simply deprecate the entire `connect_with_credentials` flow, which pretty much falls in line with E-conomics official stance.

I am not quite ready to go down that route just yet, especially not without having a working state that r-conomic users can rely on if they need to continue using `connect_with_credentials`.
