### PR TITLE
Force usage of Savon prior to 2.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changes
 
-*
+* Tighten Savon dependency. Due to changes in Savons internal API we cannot work with versions 2.11.2 or later.
 
 ### Removed
 

--- a/rconomic.gemspec
+++ b/rconomic.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.version     = Rconomic::VERSION
   s.platform    = Gem::Platform::RUBY
 
-  s.add_runtime_dependency "savon", "~> 2.2"
+  s.add_runtime_dependency "savon", "~> 2.2", "< 2.11.2"
   s.add_development_dependency "rspec", "> 3.0"
 
   s.files         = `git ls-files`.split("\n").reject { |filename| [".gitignore"].include?(filename) }


### PR DESCRIPTION
Savon 2.11.1 has the version of Savon::SoapRequest#configure_headers method that
takes 1 argument, which we expect.

This was changed for Savon 2.11.2 to now take two arguments, causing our monkey
patch to fail.

See https://github.com/substancelab/rconomic/commit/b4286201babf0ffd35c4530b0634#commitcomment-29553483 for some discussion of this.