### PR TITLE
Debtors current invoices

### DIFF
--- a/lib/economic/debtor.rb
+++ b/lib/economic/debtor.rb
@@ -60,6 +60,12 @@ module Economic
     # Provides access to the current invoices for Debtor - ie invoices that
     # haven't yet been booked
     def current_invoices
+      @current_invoices ||= CurrentInvoiceProxy.new(self)
+    end
+
+    # Provides access to the current invoices for Debtor - ie invoices that
+    # haven't yet been booked
+    def get_current_invoices
       return [] if handle.empty?
       @current_invoices ||= DebtorProxy.new(self).get_current_invoices(handle)
     end

--- a/lib/economic/debtor.rb
+++ b/lib/economic/debtor.rb
@@ -60,7 +60,8 @@ module Economic
     # Provides access to the current invoices for Debtor - ie invoices that
     # haven't yet been booked
     def current_invoices
-      @current_invoices ||= CurrentInvoiceProxy.new(self)
+      return [] if handle.empty?
+      @current_invoices ||= DebtorProxy.new(self).get_current_invoices(handle)
     end
 
     # Returns the Debtors contacts

--- a/lib/economic/proxies/current_invoice_proxy.rb
+++ b/lib/economic/proxies/current_invoice_proxy.rb
@@ -7,6 +7,19 @@ module Economic
   class CurrentInvoiceProxy < EntityProxy
     include FindByDateInterval
 
+    # Fetches all entities from the API.
+    def all
+      if owner.is_a?(Economic::Debtor)
+        owner.get_current_invoices
+      else
+        response = request(:get_all)
+        handles = response.values.flatten.collect { |handle| Entity::Handle.build(handle) }
+        get_data_for_handles(handles)
+
+        self
+      end
+    end
+
     private
 
     # Initialize properties in invoice with values from owner

--- a/lib/economic/proxies/debtor_proxy.rb
+++ b/lib/economic/proxies/debtor_proxy.rb
@@ -18,6 +18,14 @@ module Economic
       request :get_next_available_number
     end
 
+    def get_current_invoices(debtor_handle)
+      response = fetch_response(:get_current_invoices, debtor_handle)
+      build_entities_from_response(
+        Economic::CurrentInvoice,
+        response[:current_invoice_handle]
+      )
+    end
+
     def get_debtor_contacts(debtor_handle)
       response = fetch_response(:get_debtor_contacts, debtor_handle)
       build_entities_from_response(
@@ -52,7 +60,8 @@ module Economic
         entity.partial = true
         entity.persisted = true
         entity.handle = handle
-        entity.number = handle[:id].to_i
+        entity.number = handle[:id].to_i if entity&.number
+        entity.id = handle[:id].to_i if entity&.id
         entity
       end
     end

--- a/lib/economic/proxies/debtor_proxy.rb
+++ b/lib/economic/proxies/debtor_proxy.rb
@@ -60,10 +60,19 @@ module Economic
         entity.partial = true
         entity.persisted = true
         entity.handle = handle
-        entity.number = handle[:id].to_i if entity&.number
-        entity.id = handle[:id].to_i if entity&.id
+        entity = add_id_to_entity(entity, handle[:id].to_i)
         entity
       end
+    end
+
+    def add_id_to_entity(entity, id)
+      if entity.respond_to?(:number=)
+        entity.number = id
+      else
+        entity.id = id
+      end
+
+      entity
     end
 
     def fetch_response(operation, debtor_handle)

--- a/spec/economic/debtor_spec.rb
+++ b/spec/economic/debtor_spec.rb
@@ -44,14 +44,29 @@ describe Economic::Debtor do
   end
 
   describe ".current_invoices" do
+    it "returns an CurrentInvoiceProxy" do
+      expect(subject.current_invoices).to be_instance_of(Economic::CurrentInvoiceProxy)
+    end
+
+    it "memoizes the proxy" do
+      expect(subject.current_invoices).to equal(subject.current_invoices)
+    end
+
+    it "should store the session" do
+      expect(subject.session).to_not be_nil
+      expect(subject.current_invoices.session).to eq(subject.session)
+    end
+  end
+
+  describe ".get_current_invoices" do
     it "return nothing if no handle" do
-      expect(subject.current_invoices).to be_empty
+      expect(subject.get_current_invoices).to be_empty
     end
 
     it "returns current invoices if there is a handle" do
       mock_request("Debtor_GetCurrentInvoices", {"debtorHandle" => {"Number" => "1"}}, :success)
       subject.handle = Economic::Entity::Handle.new(:number => "1")
-      subject.current_invoices.each do |i|
+      subject.get_current_invoices.each do |i|
         expect(i).to be_instance_of(Economic::CurrentInvoice)
       end
     end

--- a/spec/economic/debtor_spec.rb
+++ b/spec/economic/debtor_spec.rb
@@ -44,17 +44,16 @@ describe Economic::Debtor do
   end
 
   describe ".current_invoices" do
-    it "returns an CurrentInvoiceProxy" do
-      expect(subject.current_invoices).to be_instance_of(Economic::CurrentInvoiceProxy)
+    it "return nothing if no handle" do
+      expect(subject.current_invoices).to be_empty
     end
 
-    it "memoizes the proxy" do
-      expect(subject.current_invoices).to equal(subject.current_invoices)
-    end
-
-    it "should store the session" do
-      expect(subject.session).to_not be_nil
-      expect(subject.current_invoices.session).to eq(subject.session)
+    it "returns current invoices if there is a handle" do
+      mock_request("Debtor_GetCurrentInvoices", {"debtorHandle" => {"Number" => "1"}}, :success)
+      subject.handle = Economic::Entity::Handle.new(:number => "1")
+      subject.current_invoices.each do |i|
+        expect(i).to be_instance_of(Economic::CurrentInvoice)
+      end
     end
   end
 

--- a/spec/economic/proxies/current_invoice_proxy_spec.rb
+++ b/spec/economic/proxies/current_invoice_proxy_spec.rb
@@ -136,5 +136,16 @@ describe Economic::CurrentInvoiceProxy do
       expect(current_invoices.first).to be_instance_of(Economic::CurrentInvoice)
       expect(current_invoices.last).to be_instance_of(Economic::CurrentInvoice)
     end
+
+    context "owner is a debtor" do
+      let(:debtor) { make_debtor }
+      subject { Economic::CurrentInvoiceProxy.new(debtor) }
+
+      it "asks for the owners current invoices" do
+        expect(debtor).to receive(:get_current_invoices) { [] }
+
+        subject.all
+      end
+    end
   end
 end

--- a/spec/fixtures/debtor_get_current_invoices/success.xml
+++ b/spec/fixtures/debtor_get_current_invoices/success.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Body>
+    <Debtor_GetCurrentInvoicesResponse xmlns="http://e-conomic.com">
+      <Debtor_GetCurrentInvoicesResult>
+        <CurrentInvoiceHandle>
+          <Id>1</Id>
+        </CurrentInvoiceHandle>
+        <CurrentInvoiceHandle>
+          <Id>2</Id>
+        </CurrentInvoiceHandle>
+      </Debtor_GetCurrentInvoicesResult>
+    </Debtor_GetCurrentInvoicesResponse>
+  </soap:Body>
+</soap:Envelope>


### PR DESCRIPTION
If you called `Debtor#current_invoices.all` you would get a simple representation of all current invoices for the session instead of the debtors own current invoices.

This change will make it possible to get the debtors invoices when calling the proxy `#all`, which is at least a little closer to the expected behaviour.