### PR TITLE
Make `get_data_for_handles` publicly available

### DIFF
--- a/lib/economic/proxies/entity_proxy.rb
+++ b/lib/economic/proxies/entity_proxy.rb
@@ -74,6 +74,22 @@ module Economic
       entity
     end
 
+    def get_data_for_handles(handles)
+      if handles.size == 1
+        # Fetch data for single entity
+        find(handles.first.to_hash)
+      elsif handles.size > 1
+        # Fetch all data for all the entities
+        entity_data = get_data_array(handles)
+
+        # Build Entity objects and add them to the proxy
+        entity_data.each do |data|
+          entity = build(data)
+          entity.persisted = true
+        end
+      end
+    end
+
     # Gets data for Entity from the API. Returns Hash with the response data
     def get_data(handle)
       handle = Entity::Handle.new(handle)
@@ -115,22 +131,6 @@ module Economic
       entity_class_name_for_soap_request = entity_class.name.split("::").last
       response = request(:get_data_array, "entityHandles" => {"#{entity_class_name_for_soap_request}Handle" => handles.collect(&:to_hash)})
       [response["#{entity_class.key}_data".intern]].flatten
-    end
-
-    def get_data_for_handles(handles)
-      if handles.size == 1
-        # Fetch data for single entity
-        find(handles.first.to_hash)
-      elsif handles.size > 1
-        # Fetch all data for all the entities
-        entity_data = get_data_array(handles)
-
-        # Build Entity objects and add them to the proxy
-        entity_data.each do |data|
-          entity = build(data)
-          entity.persisted = true
-        end
-      end
     end
 
     # Removes all loaded items

--- a/spec/economic/proxies/current_invoice_proxy_spec.rb
+++ b/spec/economic/proxies/current_invoice_proxy_spec.rb
@@ -6,6 +6,43 @@ describe Economic::CurrentInvoiceProxy do
   let(:session) { make_session }
   subject { Economic::CurrentInvoiceProxy.new(session) }
 
+  describe ".get_data_for_handles" do
+    context "single handle" do
+      let(:handle) { Economic::Entity::Handle.new(:id => 42) }
+
+      it "returns single" do
+        mock_request(
+          "CurrentInvoice_GetData",
+          {"entityHandle" => {"Id" => 42}},
+          :success
+        )
+
+        expect(subject.get_data_for_handles([handle])).to \
+          be_a(Economic::CurrentInvoice)
+      end
+    end
+
+    context "more handles" do
+      let(:handles) do
+        [
+          Economic::Entity::Handle.new(:id => 42),
+          Economic::Entity::Handle.new(:id => 44)
+        ]
+      end
+
+      it "returns multiple" do
+        mock_request(
+          "CurrentInvoice_GetDataArray",
+          :any,
+          :multiple
+        )
+
+        expect(subject.get_data_for_handles(handles)).to \
+          be_a(Array)
+      end
+    end
+  end
+
   describe ".new" do
     it "stores session" do
       expect(subject.session).to equal(session)


### PR DESCRIPTION
So we can fetch data for many entities.